### PR TITLE
Support the + operator

### DIFF
--- a/spdx/lexer.go
+++ b/spdx/lexer.go
@@ -3,6 +3,7 @@ package spdx
 import (
 	"fmt"
 	"io"
+	"strings"
 )
 
 // Lexer will parse expressions and get all tokens from it.
@@ -104,8 +105,12 @@ func (s *Lexer) genOperatorTokenFrom(head int) (*Token, error) {
 
 func (s *Lexer) genLicenseTokenFrom(head int) (*Token, error) {
 	license := string(s.expression[head:s.index])
+
+	// remove the + operator if any
+	baseLicense := strings.TrimRight(license, "+")
+
 	s.isOperator = true
-	if _, ok := validLicenses[license]; !ok {
+	if _, ok := validLicenses[baseLicense]; !ok {
 		s.index = head
 		return nil, InvalidLicenseError(s.errorf("invalid license %q", license))
 	}

--- a/spdx/parser_test.go
+++ b/spdx/parser_test.go
@@ -28,6 +28,12 @@ func TestParse(t *testing.T) {
 		assert.Equal(t, LicenseID("0BSD"), exp)
 	})
 
+	t.Run("single-license-and-later", func(t *testing.T) {
+		exp, err := Parse("MPL-2.0+")
+		assert.NoError(t, err)
+		assert.Equal(t, LicenseID("MPL-2.0+"), exp)
+	})
+
 	t.Run("simple-expression", func(t *testing.T) {
 		exp, err := Parse("0BSD OR AAL AND Abstyles")
 		assert.NoError(t, err)


### PR DESCRIPTION
This PR fixes #1 by adding support for the `+` suffix introduced by SPDX 2.0.